### PR TITLE
Add `\cghost{}` and `\nghost{}` to have alternative inputs to gates

### DIFF
--- a/Qtutorial.tex
+++ b/Qtutorial.tex
@@ -469,6 +469,20 @@ To indicate a generalized circuit with $n$ iterations of something, you could us
      & \qw & \qw & \qw & \ctrl{-4} & \qw \\
 }\end{verbatim}}
 
+In addition it is possible to use a classical input to a gate with \verb=\cghost=, or no input with \verb=\nghost=.
+\[ \Qcircuit @C=1em @R=0em {
+& \qw    & \multigate{3}{U} & \qw & \qw \\
+& \cw    &       \cghost{U} & \cw & \cw \\
+& \cdots &       \nghost{U} & \cdots &  \\
+& \qw    &        \ghost{U} & \qw & \qw
+}\]
+{\small \begin{verbatim}\Qcircuit @C=1em @R=0em {
+& \qw    & \multigate{3}{U} & \qw & \qw \\
+& \cw    &       \cghost{U} & \cw & \cw \\
+& \cdots &       \nghost{U} & \cdots &  \\
+& \qw    &        \ghost{U} & \qw & \qw
+}\end{verbatim}}
+
 \subsection{How to control anything}
 
 Controlled-Z gates, wires with bends, and gates that control-on-zero can all be made using the extended family of control commands.  The complete family of control commands is \verb=\ctrl=, \verb=\cctrl=, \verb=\ctrlo=, \verb=\cctrlo=, \verb=\control=, and \verb=\controlo=.
@@ -687,7 +701,9 @@ The following table is grouped according to the effect of each command.\\
                     \char92 qswap \\
                     \char92 multigate\{\#1\}\{\#2\} \\
                     \char92 sgate\{\#1\}\{\#2\}\\
-                    \char92 ghost\{\#1\} }\\
+                    \char92 ghost\{\#1\} \\
+                    \char92 cghost\{\#1\} \\
+                    \char92 nghost\{\#1\} }\\
         Controls & \parbox[t]{6cm}{\tt
                     \char92 ctrl\{\#1\} \\
                     \char92 ctrlo\{\#1\} \\

--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -137,6 +137,10 @@
 \newcommand{\ghost}[1]{*+<1em,.9em>{\hphantom{#1}} \qw}
     % Leaves space for \multigate on wires other than the one on which \multigate appears.  Without this command wires will cross your gate.
     % #1 should match the second argument in the corresponding \multigate.
+\newcommand{\cghost}[1]{*+<1em,.9em>{\hphantom{#1}} \cw}
+    % Same as ghost but with a classical incoming wire.
+\newcommand{\nghost}[1]{*+<1em,.9em>{\hphantom{#1}}}
+    % Same as ghost but with no incoming wire.
 \newcommand{\push}[1]{*{#1}}
     % Inserts #1, overriding the default that causes entries to have zero size.  This command takes the place of a gate.
     % Like a gate, it must precede any wire commands.


### PR DESCRIPTION
Hi,

I've found that having only the standard `\qw` wire for input to multigates is a little restrictive, so I created `\cghost{}` and `\nghost{}` to have a classical input or no input.

Maybe this feature could be inplemented as an option of `\ghost{}`. Also I thought to use `\ghost*{}` instead of `\nghost{}` but didn't want to change too much your code.  

I know classical input to a quantum gate can sound strange, but at least in optics it happens.

Here is the exemple I've put in the doc:
```latex
\documentclass[border=3pt]{standalone}
\usepackage{qcircuit}

\begin{document}

\Qcircuit @C=1em @R=0em {%
& \qw    & \multigate{3}{U^\dagger} & \qw & \qw \\
& \cw    & \cghost{U^\dagger}       & \cw & \cw \\
& \cdots & \nghost{U^\dagger}       & \cdots \\
& \qw    &  \ghost{U^\dagger}       & \qw & \qw
}

\end{document}
```

![test.pdf](https://github.com/CQuIC/qcircuit/files/1476701/test.pdf)

And many thanks for that nice package,
Élie
