### PR TITLE
Add parameter to \barrier command for horizontal offset

### DIFF
--- a/Qtutorial.tex
+++ b/Qtutorial.tex
@@ -483,6 +483,45 @@ In addition it is possible to use a classical input to a gate with \verb=\cghost
 & \qw    &        \ghost{U} & \qw & \qw
 }\end{verbatim}}
 
+\subsection{Barriers}
+
+You can use the \verb=\barrier= command to draw a barrier in your circuit. This
+will be represented as a vertical dashed line in your circuit. The number of
+bits downard to span is is adjustable and must be specified when adding it to
+your circuit. If you want to span just a single qubit you use 0.
+
+Here is a simple example that adds a barrier over 2 qubits on a small
+circuit:
+
+\[ \Qcircuit {
+    & \gate{X} \barrier{1} & \qw \\
+    & \gate{X} & \qw \\
+}\]
+
+{\small \begin{verbatim} \Qcircuit {
+    & \gate{X} \barrier{1}  & \qw \\
+    & \gate{X} & \qw \\
+}\end{verbatim}}
+
+
+The other complication with drawing barriers is that because spacing between
+elements on a circuit are not a fixed distance finding the exact spot to place
+a barrier on a circuit may need manual adjustment. There is an optional
+parameter for the \verb=\barrier= command to specify the horizontal offset from
+the location you're placing it. For example:
+
+\[ \Qcircuit {
+    & \gate{X} \barrier[-1.95em]{1} & \meter & \qw \\
+    & \gate{X} & \qw & \qw \\
+    & \cw & \cw \cwx[-2] & \cw \\
+}\]
+
+{\small \begin{verbatim} \Qcircuit  {
+    & \gate{X} \barrier[-1.95em]{1} & \meter & \qw \\
+    & \gate{X} & \qw & \qw \\
+    & \cw & \cw \cwx[-2] & \cw  \\
+}\end{verbatim}}
+
 \subsection{How to control anything}
 
 Controlled-Z gates, wires with bends, and gates that control-on-zero can all be made using the extended family of control commands.  The complete family of control commands is \verb=\ctrl=, \verb=\cctrl=, \verb=\ctrlo=, \verb=\cctrlo=, \verb=\control=, and \verb=\controlo=.

--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -76,11 +76,13 @@
 \newcommand{\cds}[2]{*+<1em,.9em>{\hphantom{#2}} \POS [0,0].[#1,0]="e",!C *{#2};"e"+ R \qw}
     % Allows the insertion of text without a box and exands circuit around this text.
     % This is useful for such things as ... to indicate a generalized circuit.
-\newcommand{\barrier}[1]{\ar @{--}[#1,1]+<0.95em, -1em>;[0,1]+<0.95em, 1em>}
+\newcommand{\barrier}[2][-0.95em]{\ar @{--}[#2,1]+<#1, -1em>;[0,1]+<#1, 1em>}
     % Defines a barrier that is represented by a horizontal dashed line.
     % It takes a a single argument to specify how many bits to cover
+    % To center the barrier between gates you can adjust the horizontal offset
+    % with an optional second parameter. This is the horizontal offset in em.
+    % It defaults to -0.95em
     % WARNING: Be sure to place the barrier on the topmost bit it covers, it only propogates downwards
-    % WARNING: The line has fixed offsets (.95 em horizontally) in attempt to center the line between gates
 \newcommand{\gate}[1]{*+<.6em>{#1} \POS ="i","i"+UR;"i"+UL **\dir{-};"i"+DL **\dir{-};"i"+DR **\dir{-};"i"+UR **\dir{-},"i" \qw}
     % Boxes the argument, making a gate.
 \newcommand{\sgate}[2]{\gate{#1}  \qwx[#2]}


### PR DESCRIPTION
This commit adds a new parameter to the \barrier command to specify a
manual offset to place the barrier from placement. The distance between
elements on a circuit is not fixed and figure out how to place the
barrier may require manual adjustment.

This also adds documentation on how to use the \barrier command to
Qtutorial.tex so there will be a guide on how to use it.