### PR TITLE
Add \ncds to do the same as \cds without wire.

### DIFF
--- a/Qtutorial.tex
+++ b/Qtutorial.tex
@@ -483,6 +483,23 @@ To indicate a generalized circuit with $n$ iterations of something, you could us
      & \qw & \qw & \qw & \ctrl{-4} & \qw \\
 }\end{verbatim}}
 
+To do the same without wires, you could use the \verb=\ncds= command.
+\[\Qcircuit @C=1em @R=.7em {
+     & \targ & \targ & \qw & \ncds{4}{\cdots}
+          && \targ & \qw\\
+     & \ctrl{-1} & \qw & \qw & && \qw & \qw \\
+     & \qw & \ctrl{-2} & \qw & && \qw & \qw \\
+     & & & && & \\
+     & \qw & \qw & \qw & && \ctrl{-4} & \qw \\
+}\]
+{\small \begin{verbatim}\Qcircuit @C=1em @R=.3em {
+     & \targ & \targ & \qw & \ncds{4}{\cdots}
+          && \targ & \qw\\
+     & \ctrl{-1} & \qw & \qw & && \qw & \qw \\
+     & \qw & \ctrl{-2} & \qw & && \qw & \qw \\
+     & & & && & \\
+     & \qw & \qw & \qw & && \ctrl{-4} & \qw \\
+}\end{verbatim}}
 
 \subsection{Barriers}
 
@@ -753,7 +770,8 @@ The following table is grouped according to the effect of each command.\\
                     @!C \\
                     @! \\
                     \char92 push\{\#1\} \\
-                    \char92 cds\{\#1\}\{\#2\}}\\
+                    \char92 cds\{\#1\}\{\#2\} \\
+                    \char92 ncds\{\#1\}\{\#2\}}\\
         Wires & \parbox[t]{6cm}{\tt
                     \char92 qw[\#1] \\
                     \char92 qwx[\#1] \\

--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -76,6 +76,8 @@
 \newcommand{\cds}[2]{*+<1em,.9em>{\hphantom{#2}} \POS [0,0].[#1,0]="e",!C *{#2};"e"+ R \qw}
     % Allows the insertion of text without a box and exands circuit around this text.
     % This is useful for such things as ... to indicate a generalized circuit.
+\newcommand{\ncds}[2]{{\hphantom{#2}} \POS [0,0].[#1,0]="e",!C *{#2};"e"+ R}
+    % As \cds without incoming wire and extra space.
 \newcommand{\barrier}[2][-0.95em]{\ar @{--}[#2,1]+<#1, -1em>;[0,1]+<#1, 1em>}
     % Defines a barrier that is represented by a horizontal dashed line.
     % It takes a a single argument to specify how many bits to cover


### PR DESCRIPTION
As described in the title, it adds a command (`\ncds`) to do the same as `\nds` but without wire.

An example is included in the commit (in the documentation).
Another example is:
```latex
\Qcircuit @C=1em @R=.7em {
	& \gate{\phi} & \qw & \ncds{1}{=} & & \ctrl{1}   & \qw \\
	& \ctrl{-1}   & \qw &	          & &\gate{\phi} & \qw
}
```

Since I don't understand everything in the code I've written, I encourage you to carefully read it.