### PR TITLE
added gate with incoming classical wire

### DIFF
--- a/Qtutorial.tex
+++ b/Qtutorial.tex
@@ -445,6 +445,18 @@ Q-circuit also includes the commands \verb=\multimeasure= and \verb=\multimeasur
      & \gate{\ket{\xi_{\pm}}} & \qw \\
 }\end{verbatim}}
 
+The \verb=\gate= command draws a gate with an incoming quantum wire. In contrast, the \verb=\cgate= command draws a gate with an incoming classical wire, and it can be useful for resetting a qubit after measurement:
+\[\Qcircuit @C=1em @R=.7em {
+    & \qw    & \gate{X}              & \qw             & \qw \\
+    & \meter & \control \cw \cwx[-1] & \cgate{\ket{0}} & \qw
+}\]
+{\small \begin{verbatim}\Qcircuit @C=1em @R=.7em {
+    & \qw & \gate{X} & \qw & \qw \\
+    & \meter & \control \cw \cwx[-1] 
+        & \cgate{\ket{0}} & \qw
+}\end{verbatim}}
+
+
 \subsection{Non-gate inserts, forcing space, and swap \label{S:inserts}}
 
 In addition to the gates defined by Q-circuit, standard \LaTeX\ can function as a gate if enclosed in curly brackets.  By default, inputs are assumed to have zero size, so no space will be made for the resulting object and any wires connecting to it will run straight to the object's middle.  Standard \LaTeX\ entries can serve as labels or wire decorations.

--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -85,6 +85,8 @@
     % WARNING: Be sure to place the barrier on the topmost bit it covers, it only propogates downwards
 \newcommand{\gate}[1]{*+<.6em>{#1} \POS ="i","i"+UR;"i"+UL **\dir{-};"i"+DL **\dir{-};"i"+DR **\dir{-};"i"+UR **\dir{-},"i" \qw}
     % Boxes the argument, making a gate.
+\newcommand{\cgate}[1]{*+<.6em>{#1} \POS ="i","i"+UR;"i"+UL **\dir{-};"i"+DL **\dir{-};"i"+DR **\dir{-};"i"+UR **\dir{-},"i" \cw}
+    % Boxes the argument, making a gate, with an incoming classical wire.
 \newcommand{\sgate}[2]{\gate{#1}  \qwx[#2]}
     % Creates a gate and a qwx wire going #2 spots below, for a gate split over
     % non-adjacent rows


### PR DESCRIPTION
Added \cgate, which is a gate but with a classical incoming wire instead of a quantum incoming wire. This is useful for creating resets, as shown in the bottom-right corner of the following circuit:
![Screenshot_2021-11-02_13-31-36](https://user-images.githubusercontent.com/35974880/139916130-cc76b8ef-5328-4c57-b310-6902b1f1994d.png)
