### PR TITLE
Removed \pureghost

### DIFF
--- a/qcircuit.sty
+++ b/qcircuit.sty
@@ -181,7 +181,5 @@
     % Defines \Qcircuit as an \xymatrix with entries of default size 0em.
 \newcommand{\link}[2]{\ar @{-} [#1,#2]}
     % Draws a wire or connecting line to the element #1 rows down and #2 columns forward.
-\newcommand{\pureghost}[1]{*+<1em,.9em>{\hphantom{#1}}}
-    % Same as \ghost except it omits the wire leading to the left. 
 
 \endinput


### PR DESCRIPTION
It's exactly the same as \nghost, so it's not needed.